### PR TITLE
Front/feature/password ux

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -10,7 +10,13 @@ import {
   Container,
   Box,
   useToast,
+  InputGroup,
+  InputRightElement,
+  Icon,
 } from "@chakra-ui/react";
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
+
+import { useState } from "react";
 
 //自動ログイン機能は後で実装
 
@@ -22,6 +28,7 @@ type formInputs = {
 const Login = () => {
   const navigate = useNavigate();
   const toast = useToast();
+  const [showPassword, setShowPassword] = useState(false);
 
   const {
     handleSubmit,
@@ -45,6 +52,8 @@ const Login = () => {
   const onClickLogin = async () => {
     navigate("/fresherTop");
   };
+
+  const handleClickPassword = () => setShowPassword(!showPassword);
 
   return (
     <Box>
@@ -92,24 +101,38 @@ const Login = () => {
               paddingBottom={6}
             >
               <FormLabel>パスワード</FormLabel>
-              <Input
-                type="user-password"
-                {...register("user_password", {
-                  required: "必須項目です",
-                  minLength: {
-                    value: 8,
-                    message: "8文字以上で入力してください",
-                  },
-                  maxLength: {
-                    value: 50,
-                    message: "50文字以内で入力してください",
-                  },
-                  pattern: {
-                    value: /^[0-9a-zA-Z]*$/,
-                    message: "半角英数字で入力してください",
-                  },
-                })}
-              />
+              <InputGroup>
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  {...register("user_password", {
+                    required: "必須項目です",
+                    minLength: {
+                      value: 8,
+                      message: "8文字以上で入力してください",
+                    },
+                    maxLength: {
+                      value: 50,
+                      message: "50文字以内で入力してください",
+                    },
+                    pattern: {
+                      value: /^[0-9a-zA-Z]*$/,
+                      message: "半角英数字で入力してください",
+                    },
+                  })}
+                />
+                <InputRightElement
+                  marginRight={2}
+                  height={"100%"}
+                  onClick={handleClickPassword}
+                >
+                  {showPassword ? (
+                    <Icon as={ViewIcon} />
+                  ) : (
+                    <Icon as={ViewOffIcon} />
+                  )}
+                </InputRightElement>
+              </InputGroup>
               <FormErrorMessage>
                 {errors.user_password && errors.user_password.message}
               </FormErrorMessage>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -10,12 +10,20 @@ import {
   Button,
   Box,
   useToast,
+  Divider,
+  AbsoluteCenter,
+  InputRightElement,
+  InputGroup,
+  Icon,
 } from "@chakra-ui/react";
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
+import { useState } from "react";
 
 type formInputs = {
   user_name: string;
   user_address: string;
   user_password: string;
+  user_passwordConfirm: string;
   company_id: string;
   company_password: string;
 };
@@ -27,6 +35,7 @@ const Signup = () => {
   const {
     handleSubmit,
     register,
+    getValues,
     formState: { errors, isSubmitting },
   } = useForm<formInputs>();
 
@@ -43,8 +52,14 @@ const Signup = () => {
     navigate("/login");
   });
 
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+  const handleClickPassword = () => setShowPassword(!showPassword);
+  const handleClickPasswordConfirm = () =>
+    setShowPasswordConfirm(!showPasswordConfirm);
+
   return (
-    <Box>
+    <Box maxH="100%" maxW="80%" margin="auto">
       <Container
         paddingTop={6}
         marginTop={10}
@@ -54,16 +69,26 @@ const Signup = () => {
         borderRadius={"md"}
         centerContent
       >
-        <Text fontSize="3xl" as="b" paddingY={2}>
+        <Text fontSize="2xl" as="b" paddingY={1}>
           新規登録
         </Text>
         <form onSubmit={onSubmit}>
-          <Box width="sm" paddingY={6} textAlign={"center"}>
+          <Box width="sm" paddingY={2} textAlign={"center"}>
+            <Box position="relative" paddingY={6}>
+              <Divider />
+              <AbsoluteCenter bg="white" px="4">
+                個人情報
+              </AbsoluteCenter>
+            </Box>
+
             {/* ユーザー名 */}
-            <FormControl isInvalid={Boolean(errors.user_name)} mb={5}>
-              <FormLabel htmlFor="name">ユーザー名</FormLabel>
+            <FormControl isInvalid={Boolean(errors.user_name)} mb={4}>
+              <FormLabel htmlFor="name" fontSize="sm">
+                ユーザー名
+              </FormLabel>
               <Input
                 id="name"
+                size="sm"
                 // 必須と50文字以内のバリデーション
                 {...register("user_name", {
                   required: "必須項目です",
@@ -77,11 +102,15 @@ const Signup = () => {
                 {errors.user_name && errors.user_name.message}
               </FormErrorMessage>
             </FormControl>
+
             {/* メールアドレス */}
-            <FormControl isInvalid={Boolean(errors.user_address)} mb={5}>
-              <FormLabel htmlFor="email">メールアドレス</FormLabel>
+            <FormControl isInvalid={Boolean(errors.user_address)} mb={4}>
+              <FormLabel htmlFor="email" fontSize="sm">
+                メールアドレス
+              </FormLabel>
               <Input
                 id="email"
+                size="sm"
                 // 必須、50文字以内、半角英数字メールアドレス形式のバリデーション
                 {...register("user_address", {
                   required: "必須項目です",
@@ -99,36 +128,114 @@ const Signup = () => {
                 {errors.user_address && errors.user_address.message}
               </FormErrorMessage>
             </FormControl>
-            <FormControl isInvalid={Boolean(errors.user_password)} mb={5}>
-              <FormLabel htmlFor="user_password">パスワード</FormLabel>
-              <Input
-                id="user_password"
-                // 必須、8文字以上、50文字以内、半角英数字のバリデーション
-                {...register("user_password", {
-                  required: "必須項目です",
-                  minLength: {
-                    value: 8,
-                    message: "8文字以上で入力してください",
-                  },
-                  maxLength: {
-                    value: 50,
-                    message: "50文字以内で入力してください",
-                  },
-                  pattern: {
-                    value: /^[0-9a-zA-Z]*$/,
-                    message: "半角英数字で入力してください",
-                  },
-                })}
-              />
+            <FormControl isInvalid={Boolean(errors.user_password)} mb={4}>
+              <FormLabel htmlFor="user_password" fontSize="sm">
+                パスワード
+              </FormLabel>
+              <InputGroup size="md">
+                <Input
+                  id="user_password"
+                  size="sm"
+                  type={showPassword ? "text" : "password"}
+                  // 必須、8文字以上、50文字以内、半角英数字のバリデーション
+                  {...register("user_password", {
+                    required: "必須項目です",
+                    minLength: {
+                      value: 8,
+                      message: "8文字以上で入力してください",
+                    },
+                    maxLength: {
+                      value: 50,
+                      message: "50文字以内で入力してください",
+                    },
+                    pattern: {
+                      value: /^[0-9a-zA-Z]*$/,
+                      message: "半角英数字で入力してください",
+                    },
+                  })}
+                />
+                <InputRightElement
+                  marginRight={2}
+                  height={"100%"}
+                  onClick={handleClickPassword}
+                >
+                  {showPassword ? (
+                    <Icon as={ViewIcon} />
+                  ) : (
+                    <Icon as={ViewOffIcon} />
+                  )}
+                </InputRightElement>
+              </InputGroup>
               <FormErrorMessage>
                 {errors.user_password && errors.user_password.message}
               </FormErrorMessage>
             </FormControl>
+
+            <FormControl
+              isInvalid={Boolean(errors.user_passwordConfirm)}
+              mb={4}
+            >
+              <FormLabel htmlFor="user_passwordConfirm" fontSize="sm">
+                確認パスワード
+              </FormLabel>
+              <InputGroup size="md">
+                <Input
+                  id="user_passwordConfirm"
+                  size="sm"
+                  type={showPasswordConfirm ? "text" : "password"}
+                  // 必須、8文字以上、50文字以内、半角英数字、パスワードと一致するかのバリデーション
+                  {...register("user_passwordConfirm", {
+                    required: "必須項目です",
+                    minLength: {
+                      value: 8,
+                      message: "8文字以上で入力してください",
+                    },
+                    maxLength: {
+                      value: 50,
+                      message: "50文字以内で入力してください",
+                    },
+                    pattern: {
+                      value: /^[0-9a-zA-Z]*$/,
+                      message: "半角英数字で入力してください",
+                    },
+                    validate: (value) =>
+                      value === getValues("user_password") ||
+                      "パスワードが一致しません",
+                  })}
+                />
+                <InputRightElement
+                  marginRight={2}
+                  height={"100%"}
+                  onClick={handleClickPasswordConfirm}
+                >
+                  {showPasswordConfirm ? (
+                    <Icon as={ViewIcon} />
+                  ) : (
+                    <Icon as={ViewOffIcon} />
+                  )}
+                </InputRightElement>
+              </InputGroup>
+              <FormErrorMessage>
+                {errors.user_passwordConfirm &&
+                  errors.user_passwordConfirm.message}
+              </FormErrorMessage>
+            </FormControl>
+
+            <Box position="relative" paddingY={6}>
+              <Divider />
+              <AbsoluteCenter bg="white" px="4">
+                会社情報
+              </AbsoluteCenter>
+            </Box>
+
             {/* 会社ID */}
-            <FormControl isInvalid={Boolean(errors.company_id)} mb={5}>
-              <FormLabel htmlFor="company_id">会社ID</FormLabel>
+            <FormControl isInvalid={Boolean(errors.company_id)} mb={4}>
+              <FormLabel htmlFor="company_id" fontSize="sm">
+                会社ID
+              </FormLabel>
               <Input
                 id="company_id"
+                size="sm"
                 // 必須と50文字以内のバリデーション
                 {...register("company_id", {
                   required: "必須項目です",
@@ -142,11 +249,15 @@ const Signup = () => {
                 {errors.company_id && errors.company_id.message}
               </FormErrorMessage>
             </FormControl>
+
             {/* 会社パスワード */}
-            <FormControl isInvalid={Boolean(errors.company_password)} mb={5}>
-              <FormLabel htmlFor="company_password">会社パスワード</FormLabel>
+            <FormControl isInvalid={Boolean(errors.company_password)} mb={4}>
+              <FormLabel htmlFor="company_password" fontSize="sm">
+                会社パスワード
+              </FormLabel>
               <Input
                 id="company_password"
+                size="sm"
                 // 必須と50文字以内のバリデーション
                 {...register("company_password", {
                   required: "必須項目です",

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -132,7 +132,7 @@ const Signup = () => {
               <FormLabel htmlFor="user_password" fontSize="sm">
                 パスワード
               </FormLabel>
-              <InputGroup size="md">
+              <InputGroup>
                 <Input
                   id="user_password"
                   size="sm"
@@ -178,7 +178,7 @@ const Signup = () => {
               <FormLabel htmlFor="user_passwordConfirm" fontSize="sm">
                 確認パスワード
               </FormLabel>
-              <InputGroup size="md">
+              <InputGroup>
                 <Input
                   id="user_passwordConfirm"
                   size="sm"


### PR DESCRIPTION
# サインアップ画面

- 確認フォーム追加
- 表示・非表示
- 個人情報と会社情報を分けて表示

![image](https://github.com/sansan-event-fusion/spark-2023-teamR/assets/81846197/cb7cd59b-801e-4134-93c0-98cab661739c)

# ログイン画面

- 表示・非表示

![image](https://github.com/sansan-event-fusion/spark-2023-teamR/assets/81846197/03c5ec3e-9c26-4843-97c4-c2a73973bc6c)
