### PR TITLE
folder API で、クエリパラメータに receiver_id を追加

### DIFF
--- a/backend/todoapp/views.py
+++ b/backend/todoapp/views.py
@@ -39,6 +39,7 @@ class FolderViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         query_type = self.request.query_params.get("type", None)
         status = self.request.query_params.get("status", None)
+        receiver_id = self.request.query_params.get("receiver_id", None)
         queryset = Folder.objects.all()
         if status:
             queryset = queryset.filter(status=status)
@@ -49,6 +50,10 @@ class FolderViewSet(viewsets.ModelViewSet):
         elif query_type == "sent":
             queryset = queryset.filter(sender_id=self.request.user).order_by(
                 "-created_at"
+            )
+        if receiver_id:
+            queryset = queryset.filter(sender_id=self.request.user).filter(
+                receiver_id=receiver_id
             )
         return queryset
 


### PR DESCRIPTION
ログイン中のユーザが sender で、receiver_id を id とするユーザが receiver であるフォルダ情報を取得できるようにしました。
API 洗い出しの 4. に該当します。